### PR TITLE
Update to 1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ About appdirs
 
 Home: http://github.com/ActiveState/appdirs
 
-Package license: MIT License
+Package license: MIT
 
 Feedstock license: BSD 3-Clause
 
-Summary: A small Python module for determining appropriate platform-specific dirs
+Summary: A small Python module for determining appropriate platform-specific dirs.
 
 
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
-if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.2" %}
+{% set version = "1.4.3" %}
 
 package:
   name: appdirs
@@ -7,7 +7,7 @@ package:
 source:
   fn: appdirs-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/a/appdirs/appdirs-{{ version }}.tar.gz
-  sha256: e2de7ae2b3be52542b711eacf4221683f1d2f7706a5550cb2c562ee4ba93ee74
+  sha256: 9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92
 
 build:
   number: 0


### PR DESCRIPTION
```
[PR #76] Python 3.6 invalid escape sequence deprecation fixes
Fix for Python 3.6 support
```